### PR TITLE
Update MotorWare patch for CAN firmware

### DIFF
--- a/firmware/firmware_can/motorware_1_01_00_18.patch
+++ b/firmware/firmware_can/motorware_1_01_00_18.patch
@@ -124,9 +124,15 @@ index 1f50131..9c7117f 100644
 +  GPIO_setHigh(obj->gpioHandle, GPIO_Number_26);
 +  GPIO_setDirection(obj->gpioHandle, GPIO_Number_26, GPIO_Direction_Input);
 diff --git a/sw/modules/hal/boards/boostxldrv8305_revA/f28x/f2806x/src/hal_2mtr.h b/sw/modules/hal/boards/boostxldrv8305_revA/f28x/f2806x/src/hal_2mtr.h
-index c463a3b..aab17f5 100644
+index c463a3b..b3c6064 100644
 --- a/sw/modules/hal/boards/boostxldrv8305_revA/f28x/f2806x/src/hal_2mtr.h
 +++ b/sw/modules/hal/boards/boostxldrv8305_revA/f28x/f2806x/src/hal_2mtr.h
+@@ -123 +123 @@ extern "C" {
+-#define HAL_turnLedOff            HAL_setGpioLow
++#define HAL_turnLedOff            HAL_setGpioHigh
+@@ -128 +128 @@ extern "C" {
+-#define HAL_turnLedOn             HAL_setGpioHigh
++#define HAL_turnLedOn             HAL_setGpioLow
 @@ -643,5 +642,0 @@ static inline void HAL_readAdcDataWithOffsets(HAL_Handle handle,HAL_Handle_mtr h
 -    value = (_iq)ADC_readResult(obj->adcHandle,ADC_ResultNumber_8);
 -    value = _IQ12mpy(value,current_sf);


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Updates the MotorWare patch for the CAN firmware to version "v18_patch2".

Changes:
- Fix `HAL_turnLedOn/Off`: The GPIO needs to be set to low to turn the LED on and high to turn it off.

Without this fix the LEDs on the board are toggled, i.e. they are off when they should be on and vice versa.

This is actually a regression.  I had fixed this already in the past in MotorWare v16 but apparently missed to re-apply it when moving to v18.

## How I Tested

By applying the new patch on vanilla MotorWare and testing with a TI LaunchPad to verify that the LEDs are now working as expected.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
